### PR TITLE
Uplift GitHub workflows to run on ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:


### PR DESCRIPTION
Updates the GitHub workflows so that they run on the latest `ubuntu-22.04` image.

https://github.com/medic/cht-core/issues/7741